### PR TITLE
update openBrowser function to return error

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
     "github.com/anaskhan96/soup"
 	"os/exec"
     "runtime"
@@ -22,7 +21,7 @@ func fetchHTML(url string) (string, error) {
 
 
 // Opens a URL in the default web browser.
-func openBrowser(url string) {
+func openBrowser(url string) error {
     var err error
     switch runtime.GOOS {
     case "linux":
@@ -33,6 +32,7 @@ func openBrowser(url string) {
         err = exec.Command("open", url).Start()
     }
     if err != nil {
-        log.Fatal(err)
+        return fmt.Errorf("failed to open browser: %w", err)
     }
+    return nil
 }

--- a/cmd/year.go
+++ b/cmd/year.go
@@ -41,7 +41,9 @@ func year(url string) {
     }
 
     fmt.Println("Please wait until browser opens !")
-    openBrowser(url)
+    if err := openBrowser(url); err != nil {
+        fmt.Printf("Error: %v\n", err)
+    }
     
     var ch int
     fmt.Println("Do you want to continue ? \nPress 1 for Yes and 0 for No : ");


### PR DESCRIPTION
Optimize openBrowser errors [COMPLETED]
===============
- Refactored the `openBrowser` function to return an error instead of logging it directly

This PR handles issue #14 

Please review @Ashrockzzz2003 , @Abhinav-ark 