### PR TITLE
Move 'Quit' and 'Back' options to the top 

### DIFF
--- a/cmd/internal/menu/coursechoose.go
+++ b/cmd/internal/menu/coursechoose.go
@@ -44,12 +44,13 @@ func (cs *CourseSelect) ChooseCourse() {
 	var subjects []Subject
 	var options []huh.Option[string]
 
+	options = append(options, huh.NewOption("Quit", "Quit"))
+
 	for _, res := range resources {
 		subject := Subject{res.Name, res.Path}
 		subjects = append(subjects, subject)
 		options = append(options, huh.NewOption(subject.name, subject.name))
 	}
-	options = append(options, huh.NewOption("Quit", "Quit"))
 
 	// First menu does NOT display history yet
 	form := huh.NewForm(

--- a/cmd/internal/menu/semchoose.go
+++ b/cmd/internal/menu/semchoose.go
@@ -46,15 +46,17 @@ func (sc *SemChoose) ChooseSemester(url string) {
 	var assessList []Assessment
 	var options []huh.Option[string]
 
+	// Add back and quit option.
+	options = append(options, huh.NewOption("Back", "Back"))
+	options = append(options, huh.NewOption("Quit", "Quit"))
+	
 	// Convert assessments to huh options.
 	for _, assessment := range assessments {
 		assess := Assessment{assessment.Name, assessment.Path}
 		assessList = append(assessList, assess)
 		options = append(options, huh.NewOption(assess.name, assess.name))
 	}
-	// Add back and quit option.
-	options = append(options, huh.NewOption("Back", "Back"))
-	options = append(options, huh.NewOption("Quit", "Quit"))
+
 	selectionDisplay := "Selection(s):\n" + strings.Join(configs.SelectionHistory, " → ")
 	// Create the form.
 	form := huh.NewForm(

--- a/cmd/internal/menu/semtable.go
+++ b/cmd/internal/menu/semtable.go
@@ -45,15 +45,17 @@ func (sc *SemTable) ChooseQuestionSetFromSemester(url string) {
 	var sems []Semester
 	var options []huh.Option[string]
 
+	// Add back and quit option.
+	options = append(options, huh.NewOption("Back", "Back"))
+	options = append(options, huh.NewOption("Quit", "Quit"))
+
 	// Convert semesters to huh options.
 	for _, sem := range semesters {
 		semester := Semester{sem.Name, sem.Path}
 		sems = append(sems, semester)
 		options = append(options, huh.NewOption(semester.name, semester.name))
 	}
-	// Add back and quit option.
-	options = append(options, huh.NewOption("Back", "Back"))
-	options = append(options, huh.NewOption("Quit", "Quit"))
+
 	selectionDisplay := "Selection(s):\n" + strings.Join(configs.SelectionHistory, " → ")
 	// Create the form.
 	form := huh.NewForm(

--- a/cmd/internal/menu/subCommunity.go
+++ b/cmd/internal/menu/subCommunity.go
@@ -46,15 +46,17 @@ func (sct *SubCommunityTable) ChooseSubCommunity(url string) {
 		var options []huh.Option[string]
 		var subComList []SubCommunity
 
+		// Add back option.
+		options = append(options, huh.NewOption("Back to Main Menu", "back"))
+		options = append(options, huh.NewOption("Quit", "quit"))
+
 		// Convert subCommunities to huh options.
 		for _, subCommunity := range subCommunities {
 			subComItem := SubCommunity{subCommunity.Name, subCommunity.Path}
 			subComList = append(subComList, subComItem)
 			options = append(options, huh.NewOption(subComItem.name, subComItem.path))
 		}
-		// Add back option.
-		options = append(options, huh.NewOption("Back to Main Menu", "back"))
-		options = append(options, huh.NewOption("Quit", "quit"))
+
 		selectionDisplay := "Selection(s):\n" + strings.Join(configs.SelectionHistory, " → ")
 
 		// Create the select field.

--- a/cmd/internal/menu/year.go
+++ b/cmd/internal/menu/year.go
@@ -45,15 +45,17 @@ func (yt *YearTable) ChooseQP(url string) {
 		var options []huh.Option[string]
 		var fileList []File
 
+		// Add back option.
+		options = append(options, huh.NewOption("Back to Main Menu", "back"))
+		options = append(options, huh.NewOption("Quit", "quit"))
+
 		// Convert files to huh options.
 		for _, file := range files {
 			fileItem := File{file.Name, file.Path}
 			fileList = append(fileList, fileItem)
 			options = append(options, huh.NewOption(fileItem.name, fileItem.path))
 		}
-		// Add back option.
-		options = append(options, huh.NewOption("Back to Main Menu", "back"))
-		options = append(options, huh.NewOption("Quit", "quit"))
+
 		selectionDisplay := "Selection(s):\n" + strings.Join(configs.SelectionHistory, " → ")
 
 		// Create the select field.


### PR DESCRIPTION
Solves #28 
Reordered the menu options to place "Quit" and "Back" at the top. This improves visibility and allows for quicker navigation without scrolling.